### PR TITLE
Fix atoum link in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "mageekguy/atoum": "master-dev"
+        "php": ">=5.3.0"
+    },
+    "require-dev": {
+        "atoum/atoum": "master-dev"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
`mageekguy/atoum` does not exist anymore,
also moved the dependency to `require-dev` because 
I don't want **Atoum** on my production server.
