### PR TITLE
Update Opengraph.php

### DIFF
--- a/src/Opengraph/Opengraph.php
+++ b/src/Opengraph/Opengraph.php
@@ -117,10 +117,7 @@ abstract class Opengraph implements Iterator, Serializable, Countable
     
     public function __construct()
     {
-        if(is_null(static::$storage)) {
-            static::$storage = new ArrayObject();
-            //static::$position = 0;
-        }
+        static::$storage = new ArrayObject();
     }
     
     /**


### PR DESCRIPTION
When running multiple url's after each other, the storage isn't reset; 

```
$data = array();
$reader = new Opengraph\Reader();
$reader->parse(file_get_contents('http://www.imdb.com/title/tt0117500/'));
$data[] = $reader->getArrayCopy();
$reader = new Opengraph\Reader();
$reader->parse(file_get_contents('http://nu.nl/'));
$data[] = $reader->getArrayCopy();
```

When the second URL doesn't have Opengraph data, it shows the data of the first URL.
