### PR TITLE
Fallback Title and Description values

### DIFF
--- a/Tests/Units/Reader.php
+++ b/Tests/Units/Reader.php
@@ -87,21 +87,24 @@ class Reader extends Opengraph\Test\Unit
         ->isInstanceOf('\RuntimeException')
         ->hasMessage('Contents is empty');
 
-        $html = '<meta property="og:url" content="http://www.imdb.com/title/tt1074638/" />
+        $html = '<title>Skyfall Title</title>
+        <meta property="og:url" content="http://www.imdb.com/title/tt1074638/" />
         <meta property="og:title" content="Skyfall (2012)"/>
         <meta property="og:type" content="video.movie"/>
         <meta property="og:image" content="http://ia.media-imdb.com/images/M/MV5BMTczMjQ5NjE4NV5BMl5BanBnXkFtZTcwMjk0NjAwNw@@._V1._SX95_SY140_.jpg"/>
-        <meta property="og:site_name" content="IMDb"/>';
-        
+        <meta property="og:site_name" content="IMDb"/>
+        <meta name="description" content="Skyfall meta description" />
+        <meta property="og:description" content="Skyfall og description"/>';
+
         $reader = new Opengraph\Reader();
         
         $this->assert->object($reader)
             ->isInstanceOf('\Opengraph\Reader');
         
-        $reader->parse($html);
+        $reader->parse($html, true);
 
         $this->assert->integer($reader->count())
-            ->isEqualTo(5);
+            ->isEqualTo(8);
         
         $this->assert->array($reader->getArrayCopy())->isEqualTo(array(
             'og:url' => 'http://www.imdb.com/title/tt1074638/',
@@ -112,7 +115,31 @@ class Reader extends Opengraph\Test\Unit
                     'og:image:url' => 'http://ia.media-imdb.com/images/M/MV5BMTczMjQ5NjE4NV5BMl5BanBnXkFtZTcwMjk0NjAwNw@@._V1._SX95_SY140_.jpg',
                 ),
             ),
-            'og:site_name' => 'IMDb'
+            'og:site_name' => 'IMDb',
+            'non-og-description' => 'Skyfall meta description',
+            'og:description' => 'Skyfall og description',
+            'non-og-title' => 'Skyfall Title'
         ));
+
+        $reader = new Opengraph\Reader();
+
+        $reader->parse($html, false);
+
+        $this->assert->integer($reader->count())
+            ->isEqualTo(6);
+
+        $this->assert->array($reader->getArrayCopy())->isEqualTo(array(
+            'og:url' => 'http://www.imdb.com/title/tt1074638/',
+            'og:title' => 'Skyfall (2012)',
+            'og:type' => 'video.movie',
+            'og:image' => array(
+                0 => array(
+                    'og:image:url' => 'http://ia.media-imdb.com/images/M/MV5BMTczMjQ5NjE4NV5BMl5BanBnXkFtZTcwMjk0NjAwNw@@._V1._SX95_SY140_.jpg',
+                ),
+            ),
+            'og:site_name' => 'IMDb',
+            'og:description' => 'Skyfall og description'
+        ));
+
     }
 }

--- a/src/Opengraph/Reader.php
+++ b/src/Opengraph/Reader.php
@@ -45,12 +45,20 @@ class Reader extends Opengraph
         }
         
         libxml_use_internal_errors($old_libxml_error);
-        
-        foreach($dom->getElementsByTagName('meta') as $tag) { 
-            if ($tag->hasAttribute('property') && $tag->hasAttribute('content')) {
+
+        foreach($dom->getElementsByTagName('meta') as $tag) {
+            if($tag->hasAttribute('name') && $tag->hasAttribute('content') && $tag->getAttribute('name') == 'description') {
+                $this->addMeta('non-og-description', $tag->getAttribute('content'), self::APPEND);
+            } else if($tag->hasAttribute('property') && $tag->hasAttribute('content')) {
                 $this->addMeta($tag->getAttribute('property'), $tag->getAttribute('content'), self::APPEND);
-            } 
+            }
         }
+
+        $titles = $dom->getElementsByTagName('title');
+        if ($titles->length > 0) {
+            $this->addMeta('non-og-title', $titles->item(0)->textContent, self::APPEND);
+        }
+
         unset($dom);
         
         return $this;

--- a/src/Opengraph/Reader.php
+++ b/src/Opengraph/Reader.php
@@ -29,12 +29,13 @@ class Reader extends Opengraph
     }
 
     /**
-     * Parse html tags
-     * 
-     * @param String $contents
-     * @return Array
+     * parse html tags
+     *
+     * @param $contents
+     * @param bool $includeDefaults
+     * @return $this
      */
-    public function parse($contents)
+    public function parse($contents, $includeDefaults = false)
     {
         $old_libxml_error = libxml_use_internal_errors(true);
         
@@ -47,16 +48,18 @@ class Reader extends Opengraph
         libxml_use_internal_errors($old_libxml_error);
 
         foreach($dom->getElementsByTagName('meta') as $tag) {
-            if($tag->hasAttribute('name') && $tag->hasAttribute('content') && $tag->getAttribute('name') == 'description') {
+            if($includeDefaults && $tag->hasAttribute('name') && $tag->hasAttribute('content') && $tag->getAttribute('name') == 'description') {
                 $this->addMeta('non-og-description', $tag->getAttribute('content'), self::APPEND);
             } else if($tag->hasAttribute('property') && $tag->hasAttribute('content')) {
                 $this->addMeta($tag->getAttribute('property'), $tag->getAttribute('content'), self::APPEND);
             }
         }
 
-        $titles = $dom->getElementsByTagName('title');
-        if ($titles->length > 0) {
-            $this->addMeta('non-og-title', $titles->item(0)->textContent, self::APPEND);
+        if($includeDefaults) {
+            $titles = $dom->getElementsByTagName('title');
+            if ($titles->length > 0) {
+                $this->addMeta('non-og-title', $titles->item(0)->textContent, self::APPEND);
+            }
         }
 
         unset($dom);


### PR DESCRIPTION
I've found, in my usage, that it's useful to have access to the title tag and meta description as fallbacks when reading the meta data. 

This PR adds this data to the associative array returned by Reader->parse() with keys "non-og-title" and "non-og-description"

Note: This does disturb the conceptual function of Meta (ie. reading and re-writing the read results), which is why I made it optional. This might also want some refactoring.