### PR TITLE
Make tab spacing on render optional

### DIFF
--- a/src/Opengraph/Writer.php
+++ b/src/Opengraph/Writer.php
@@ -53,11 +53,11 @@ class Writer extends Opengraph
      * 
      * @return String
      */
-    public function render()
+    public function render($indent = "\t")
     {
         $html = '';
         foreach(self::$storage as $meta) {
-            $html .= "\t" . $meta->render() . PHP_EOL;
+            $html .= $indent . $meta->render() . PHP_EOL;
         }
         
         return $html;


### PR DESCRIPTION
Added a very simple optional variable when using `render()` to allow alternate line indentations (or none).