### PR TITLE
Feat.: Write Opengraph from Json

### DIFF
--- a/src/Opengraph/Writer.php
+++ b/src/Opengraph/Writer.php
@@ -49,6 +49,25 @@ class Writer extends Opengraph
     }
     
     /**
+     * Write Opengraph from Json
+     * 
+     * @param String $json
+     * @return \Opengraph\Writer return a new Writer
+     */
+    public static function fromJson($json)
+    {
+        $jsonDecoded = json_decode($json, true);
+
+        $writer = new Writer();
+
+        array_walk_recursive($jsonDecoded, function($v, $k) use ($writer) {
+            $writer->append($k, $v);
+        });
+
+        return $writer;
+    }
+
+    /**
      * Render all meta tags
      * 
      * @return String


### PR DESCRIPTION
Hello,

I created a function that makes an Opengraph from a Json. I did not do the Unity Test because I do not know how to use Atoum.

I needed this function because I saved in the database the Json returned from getArrayCopy() and I need to restore the object afterwards.

What do you think?
Thank you.